### PR TITLE
remove unneeded condition

### DIFF
--- a/index.js
+++ b/index.js
@@ -56,7 +56,7 @@ module.exports = function isAsyncFunction (fn, names, strict) {
   strict = typeof strict === 'boolean' ? strict : true
   names = typeof names === 'boolean' ? null : names
 
-  names = Array.isArray(names) ? names : arrayify(names)
+  names = arrayify(names)
   names = names.length ? names : callbackNames
 
   var idx = arrIncludes(names, functionArguments(fn))


### PR DESCRIPTION
Since [arrify](https://github.com/sindresorhus/arrify) already returns the value as is in case its an array, this condition might be unnecessary:
https://github.com/olstenlarck/is-async-function/blob/master/index.js#L59

```js
names = Array.isArray(names) ? names : arrayify(names)

// same as

names = arrayify(names)
```


arrify source:
https://github.com/sindresorhus/arrify/blob/master/index.js

```js
'use strict';
module.exports = function (val) {
	if (val === null || val === undefined) {
		return [];
	}

	return Array.isArray(val) ? val : [val];
};
```